### PR TITLE
Feat: 마이페이지 혜택 데이터 MongoDB 저장 스크립트 추가

### DIFF
--- a/scripts/seedBenefits.js
+++ b/scripts/seedBenefits.js
@@ -1,0 +1,50 @@
+import { appDeviceBenefits } from '../data/appDeviceBenefits.js';
+import { activityBenefits } from '../data/activityBenefits.js';
+import { beautyHealthBenefits } from '../data/beautyHealthBenefits.js';
+import { cultureLeisureBenefits } from '../data/cultureLeisureBenefits.js';
+import { educationBenefits } from '../data/educationBenefits.js';
+import { foodBenefits } from '../data/foodBenefits.js';
+import { lifeConvenienceBenefits } from '../data/lifeConvenienceBenefits.js';
+import { shoppingBenefits } from '../data/shoppingBenefits.js';
+import { travelTransportBenefits } from '../data/travelTransportBenefits.js';
+
+const allBenefits = [
+  appDeviceBenefits,
+  activityBenefits,
+  beautyHealthBenefits,
+  cultureLeisureBenefits,
+  educationBenefits,
+  foodBenefits,
+  lifeConvenienceBenefits,
+  shoppingBenefits,
+  travelTransportBenefits,
+];
+
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const benefitSchema = new mongoose.Schema({
+  category: String,
+  benefits: [
+    {
+      id: Number,
+      title: String,
+      descriptions: [String],
+    },
+  ],
+});
+
+const Benefit = mongoose.model('Benefit', benefitSchema);
+
+mongoose
+  .connect(process.env.MONGODB_URI)
+  .then(async () => {
+    await Benefit.deleteMany();
+    await Benefit.insertMany(allBenefits);
+    console.log('데이터가 성공적으로 저장되었습니다!');
+    mongoose.disconnect();
+  })
+  .catch((err) => {
+    console.error('에러 발생:', err);
+  });


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 마이페이지 혜택 데이터를 MongoDB에 저장하는 스크립트(`scripts/seedBenefits.js`) 추가

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- `data/` 폴더에 있는 9개 카테고리별 JS 파일을 MongoDB에 한 번에 저장하는 seed 스크립트 작성
- mongoose를 통해 `Benefit` 컬렉션에 `category`, `benefits`(id, title, descriptions) 필드 저장
- 실행 시 기존 데이터 삭제 후 새로운 데이터 일괄 삽입
- `.env`에 설정된 `MONGODB_URI`를 기준으로 DB 연결

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- MongoDB에 benefits 으로 저장되어 있는지 확인해주세요.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
