### PR TITLE
Feat: 카카오 로그인 추가 정보 입력 로직 및 최종 가입 처리 기능 추가

### DIFF
--- a/controllers/kakaoAuthController.js
+++ b/controllers/kakaoAuthController.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import { secretKey, tokenLife, cookieOptions } from '../config/jwt.js';
 import { kakaoConfig } from '../config/oauth.js';
+import { generateRandomPlanInfo } from '../utils/helpers.js';
 
 export const kakaoLogin = (req, res) => {
   const kakaoAuthURL = `https://kauth.kakao.com/oauth/authorize?client_id=${kakaoConfig.clientID}&redirect_uri=${kakaoConfig.callbackURI}&response_type=code`;
@@ -50,13 +51,12 @@ export const kakaoCallback = async (req, res) => {
     let user = await User.findOne({ kakaoId });
 
     if (!user) {
-      user = new User({
-        kakaoId,
-        name,
-        provider: 'kakao',
+      const tempToken = jwt.sign({ kakaoId, name }, secretKey, {
+        expiresIn: '10m',
       });
+      const redirectURL = process.env.FRONTEND_URL || 'http://localhost:5173';
 
-      await user.save();
+      return res.redirect(`${redirectURL}/kakao-extra-info?token=${tempToken}`);
     }
 
     const token = jwt.sign({ id: user._id, name: user.name }, secretKey, {
@@ -72,5 +72,52 @@ export const kakaoCallback = async (req, res) => {
     res
       .status(500)
       .json({ message: '카카오 로그인 처리 중 오류가 발생했습니다.' });
+  }
+};
+
+export const completeKakaoSignup = async (req, res) => {
+  const { token, isUplus } = req.body;
+
+  try {
+    const payload = jwt.verify(token, secretKey);
+    const { kakaoId, name } = payload;
+
+    if (!['yes', 'no'].includes(isUplus)) {
+      return res
+        .status(400)
+        .json({ message: 'isUplus 값이 유효하지 않습니다.' });
+    }
+
+    const existing = await User.findOne({ kakaoId });
+    if (existing) {
+      return res.status(409).json({ message: '이미 가입된 사용자입니다.' });
+    }
+
+    let planInfo = null;
+    if (isUplus === true || isUplus === 'yes') {
+      planInfo = await generateRandomPlanInfo();
+    }
+
+    const newUser = new User({
+      kakaoId,
+      name,
+      provider: 'kakao',
+      isUplus: isUplus === true || isUplus === 'yes',
+      planInfo,
+    });
+
+    await newUser.save();
+
+    const finalToken = jwt.sign({ id: newUser._id, name }, secretKey, {
+      expiresIn: tokenLife,
+    });
+
+    res
+      .cookie('access_token', finalToken, cookieOptions)
+      .status(201)
+      .json({ message: '가입 완료' });
+  } catch (err) {
+    console.error('[카카오 추가가입 오류]', err);
+    res.status(400).json({ message: '토큰이 만료되었거나 유효하지 않습니다.' });
   }
 };

--- a/routes/kakaoAuthRoutes.js
+++ b/routes/kakaoAuthRoutes.js
@@ -2,11 +2,13 @@ import express from 'express';
 import {
   kakaoLogin,
   kakaoCallback,
+  completeKakaoSignup,
 } from '../controllers/kakaoAuthController.js';
 
 const router = express.Router();
 
 router.get('/login', kakaoLogin);
 router.get('/callback', kakaoCallback);
+router.post('/complete', completeKakaoSignup);
 
 export default router;


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 카카오 로그인 추가 정보 입력 로직 및 최종 가입 처리 기능 추가

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 기존 `kakaoCallback`에서 신규 사용자인 경우 DB에 저장하지 않고, 프론트의 `/kakao-extra-info` 페이지로 `temp JWT` 포함하여 리디렉션
- 기존 사용자인 경우 바로 access_token 발급 → 쿠키 설정 후 홈(`/`)으로 리디렉션
- 새로운 컨트롤러 `completeKakaoSignup` 추가
  - 프론트에서 받은 `token`과 `isUplus` 값을 기반으로 최종 가입 처리
  - `isUplus`가 yes인 경우 `generateRandomPlanInfo`를 통해 요금제 자동 부여
  - 가입 후 access_token 발급 및 쿠키 설정
- `kakaoAuthRoutes.js`에 `/complete` POST 라우트 추가

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 카카오 신규 로그인 시 `/kakao-extra-info`로 정상 리디렉션되는지 확인해주세요
- 추가 정보 입력 후 최종 회원가입 및 자동 로그인 흐름이 잘 작동하는지 테스트해주세요

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
