### PR TITLE
Feat: 비밀번호 변경 API 추가

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -133,3 +133,29 @@ export const logoutUser = (req, res) => {
     .status(200)
     .json({ message: '로그아웃 되었습니다.' });
 };
+
+export const changePassword = async (req, res) => {
+  try {
+    const { newPassword } = req.body;
+    const userId = req.user.id;
+
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+    }
+
+    // 새 비밀번호 해싱 후 저장
+    const hashedNewPassword = await bcrypt.hash(newPassword, saltRounds);
+    user.password = hashedNewPassword;
+    await user.save();
+
+    return res
+      .status(200)
+      .json({ message: '비밀번호가 성공적으로 변경되었습니다.' });
+  } catch (error) {
+    console.error('비밀번호 변경 오류:', error);
+    return res
+      .status(500)
+      .json({ message: '서버 오류로 비밀번호 변경에 실패했습니다.' });
+  }
+};

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -5,6 +5,7 @@ import {
   loginUser,
   getMe,
   logoutUser,
+  changePassword,
 } from '../controllers/authController.js';
 
 import { verifyToken } from '../middlewares/authMiddleware.js';
@@ -16,5 +17,6 @@ router.get('/check-id', checkUserIdDuplicate);
 router.post('/login', loginUser);
 router.get('/me', verifyToken, getMe);
 router.post('/logout', logoutUser);
+router.post('/change-password', verifyToken, changePassword);
 
 export default router;


### PR DESCRIPTION
## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 비밀번호 변경 API (`/change-password`) 추가

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 인증된 사용자가 본인의 비밀번호를 변경할 수 있는 엔드포인트를 추가
- `authController.js`에 `changePassword` 함수 구현:
  - `newPassword`를 받아 `bcrypt`로 해싱한 후 DB에 저장
- `authRoutes.js`에 `/change-password` 라우터 경로 등록 (토큰 인증 필요)
- 요청 성공 시 `"비밀번호가 성공적으로 변경되었습니다."` 메시지 반환

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 변경된 비밀번호가 실제로 반영되는지 테스트 부탁드립니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
